### PR TITLE
CASMUSER-2979 fix file ownership in build before publish

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -57,6 +57,13 @@ pipeline {
                 sh "./builder.sh rpm"
             }
         }
+        stage("Chown") {
+            steps {
+                // Need to chown the files and dirs in the workspace so that
+                // publish can run.
+                postChownFiles()
+            }
+        }
         stage("BuilderClean") {
             steps {
                 sh "docker rmi --force switchboard-builder:latest"


### PR DESCRIPTION
## Summary and Scope

Fix the stable build for version 2.1.0.  This fix does not bump the version because that version never successfully built, so there was never a version 2.1.0.

This is a backward compatible bugfix.

## Issues and Related PRs

* Resolves [CASMUSER-2979](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2979)

## Testing

### Test description:

Ran build in a test stable tag and saw it work.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

There are no known risks in this change.


## Pull Request Checklist

- [ N/A ] Version number(s) incremented, if applicable
- [ N/A ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ N/A ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

